### PR TITLE
Restrict set_attribute_was patch to Rails versions >= 5.2, < 6

### DIFF
--- a/lib/attr_encrypted/adapters/active_record.rb
+++ b/lib/attr_encrypted/adapters/active_record.rb
@@ -76,7 +76,7 @@ if defined?(ActiveRecord::Base)
               # attributes are handled, @attributes[attr].value is nil which
               # breaks attribute_was. Setting it here returns us to the expected
               # behavior.
-              if Gem::Requirement.new('>= 5.2').satisfied_by?(RAILS_VERSION)
+              if Gem::Requirement.new('~> 5.2').satisfied_by?(RAILS_VERSION)
                 # This is needed support attribute_was before a record has
                 # been saved
                 set_attribute_was(attr, __send__(attr)) if value != __send__(attr)


### PR DESCRIPTION
PR https://github.com/attr-encrypted/attr_encrypted/pull/416 included a patch for ActiveRecord 5.2: https://github.com/priyankatapar/attr_encrypted/commit/7e8702bd5418c927a39d8dd72c0adbea522d5663

Apparently that change was useful Rails 5.2, but it does not work for Rails 6+. It relies on the `set_attribute_was` method, which was removed from Rails in https://github.com/rails/rails/pull/35933.

That removal would have been included in 6.0.0.rc1:
https://github.com/rails/rails/blob/6-0-stable/activerecord/CHANGELOG.md#rails-600rc1-april-24-2019

This PR addresses that by using the [pessimistic version constraint](https://guides.rubygems.org/patterns/#pessimistic-version-constraint) to limit the patch above to Rails versions >= 5.2, < 6.